### PR TITLE
Use pygments-light color style

### DIFF
--- a/book/Gremlin-Graph-Guide.adoc
+++ b/book/Gremlin-Graph-Guide.adoc
@@ -8,7 +8,7 @@ v278-preview, Mar 15, 2018
 //:Date:      Mar 15 2018
 :Numbered:
 :source-highlighter: pygments
-:pygments-style: paraiso-dark
+:pygments-style: paraiso-light
 //:pygments-style: lovelace
 //:source-highlighter: rouge
 //:source-highlighter: coderay


### PR DESCRIPTION
The `pygments-dark` color style is really hard to read on Kindle or using PDFs when there is white background. The `pygments-light` appears to be much more readable on devices.