### PR TITLE
Update command line switches for pandoc

### DIFF
--- a/book/make-book.sh
+++ b/book/make-book.sh
@@ -5,7 +5,7 @@ asciidoctor -n -b docbook -d book Gremlin-Graph-Guide.adoc -o krltemp.xml
 sed -e s/language=\"groovy\"/language=\"java\"/ krltemp.xml > Gremlin-Graph-Guide.xml
 rm krltemp.xml
 echo "*** Producing EPUB ***"
-pandoc -f docbook -t epub -N --number-sections --chapters --toc --toc-depth=4 Gremlin-Graph-Guide.xml -o Gremlin-Graph-Guide.epub
+pandoc -f docbook -t epub -N --number-sections --top-level-division=chapter --toc --toc-depth=4 Gremlin-Graph-Guide.xml -o Gremlin-Graph-Guide.epub
 echo "*** Producing MOBI ***"
 ebook-convert Gremlin-Graph-Guide.epub Gremlin-Graph-Guide.mobi
 echo "*** Producing PDF ***"


### PR DESCRIPTION
New pandoc versions don't have `--chapters` command line parameter anymore, so it doesn't execute