### PR TITLE
Fix errant object invocation

### DIFF
--- a/book/Gremlin-Graph-Guide.adoc
+++ b/book/Gremlin-Graph-Guide.adoc
@@ -21015,7 +21015,7 @@ JanusGraph can manage by itself without needing help from an external index.
 
 Using JanusGraph you can create and manipulate an index using the Management API. The
 JanusGraph documentation strongly recommends that you always make a call to
-'graph().tx().rollback()' before you start to create an index to make sure that no
+'graph.tx().rollback()' before you start to create an index to make sure that no
 other transactions are currently active.
 
 The example below shows how to use the Management API to create a new composite index


### PR DESCRIPTION
I could be wrong about this but i believe this should invoke the `tx` method on a `org.janusgraph.graphdb.database.StandardJanusGraph` object rather than trying to invoke `graph`.