### PR TITLE
Remove unneeded label 'a' from first dedup example

### DIFF
--- a/book/Gremlin-Graph-Guide.adoc
+++ b/book/Gremlin-Graph-Guide.adoc
@@ -2386,7 +2386,7 @@ what happens.
 
 [source,groovy]
 ----
-g.V().has('airport','code','AUS').as('a').out().out().as('b').out().
+g.V().has('airport','code','AUS').out().out().as('b').out().
       path().by('code').to('b').limit(10).dedup()
 
 [AUS,EWR,YYZ]

--- a/book/translations/jp/Gremlin-Graph-Guide-ja.adoc
+++ b/book/translations/jp/Gremlin-Graph-Guide-ja.adoc
@@ -1560,7 +1560,7 @@ g.V().has('airport','code','AUS').out().out().as('b').out().
 
 [source,groovy]
 ----
-g.V().has('airport','code','AUS').as('a').out().out().as('b').out().
+g.V().has('airport','code','AUS').out().out().as('b').out().
       path().by('code').to('b').limit(10).dedup()
 
 [AUS,EWR,YYZ]


### PR DESCRIPTION
Noticed an unneeded label in the [Modifying a _path_ using _from_ and _to_ modulators](https://kelvinlawrence.net/book/PracticalGremlin.html#pathfromto) section