### PR TITLE
Removed references to outdated TinkerPop versions

### DIFF
--- a/book/Section-Beyond-Basic-Queries.adoc
+++ b/book/Section-Beyond-Basic-Queries.adoc
@@ -284,7 +284,7 @@ Groovy itself is coded in Java. This means that all of the classes and methods t
 you would expect to have available while writing Groovy or Java programs are also
 available to you as you work with the Gremlin Console. You can intermix additional
 features from Groovy and Java classes along with the features provided by the
-TinkerPop 3 classes as needed. This capability makes Gremlin additionally powerful.
+TinkerPop classes as needed. This capability makes Gremlin additionally powerful.
 You can also take advantage of these features when working with Gremlin Server and
 with other TinkerPop enabled graph services with the caveat that some features may be
 blocked if viewed as a potential security risk to the server or simply because they
@@ -660,11 +660,10 @@ in the "<<testgraph>>" section that is coming up soon.
 Using a traversal to determine a new label name
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In TinkerPop 3.3.1 a new capability was added to the 'addV' and 'addE' steps. This
-new capability allows us to use a traversal to determine what the label used by a new
-vertex or edge should be. Take a look at the query below. We have seen this type of
-query used earlier in the book. It simply tells us what label the vertex representing
-the Austin (AUS) airport has.
+When using the  'addV' and 'addE' steps we can  use a traversal to determine what
+the label used by a new vertex or edge should be. Take a look at the query below.
+We have seen this type of query used earlier in the book. It simply tells us what
+label the vertex representing the Austin (AUS) airport has.
 
 [source,groovy]
 ----
@@ -673,9 +672,8 @@ g.V().has('code','AUS').label()
 airport
 ----
 
-What the new capability added in TinkerPop 3.3.1 allows us to do is include the
-traversal above inside of an 'addV' step as shown below. The first string result
-returned by the provided traversal will be used as the label name.
+The traversal above can be used inside of an 'addV' step as shown below. The first
+string result returned by the provided traversal will be used as the label name.
 
 [source,groovy]
 ----
@@ -693,9 +691,6 @@ g.V(53768).valueMap(true)
 
 [id:53768,code:[XYZ],label:airport]
 ----
-
-TIP: These features require that the graph database system you are using supports
-a TinkerPop version of 3.3.1 or higher.
 
 We can now do something similar to dynamically work out what the label should be for
 an edge between our new airport and Austin.
@@ -1182,15 +1177,15 @@ introduce in this section the concept of a property ID.
 The 'Property' and 'VertexProperty' interfaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In a TinkerPop 3 enabled graph, all properties are implementations of the 'Property'
+In a TinkerPop enabled graph, all properties are implementations of the 'Property'
 interface. Vertex properties implement the 'VertexProperty' interface which itself
 extends the 'Property' interface. These interfaces are documented as part of the
-Apache TinkerPop 3 JavaDoc. The interface defines the methods that you can use when
+Apache TinkerPop JavaDoc. The interface defines the methods that you can use when
 working with a vertex property object in your code. One important thing to note about
 vertex properties is that they are immutable. You can create them but once created
 they cannot be updated.
 
-We will look more closely at the Java interfaces that TinkerPop 3 defines in the
+We will look more closely at the Java interfaces that TinkerPop defines in the
 "<<javatinker>>" section a bit later in this book.
 
 The VertexProperty interface does not define any "setter" methods
@@ -1838,8 +1833,8 @@ g.V().has('code','AUS').valueMap('x')
 Adding properties to other properties (meta properties)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-TinkerPop 3 introduced the ability to add a property to another property. Think of
-this in a way as being able to add a bit of metadata about a property to the property
+TinkerPop has the ability to add a property to another property. Think of this in
+a way as being able to add a bit of metadata about a property to the property
 itself. This capability, not surprisingly, is often referred to as '"adding a meta
 property to a property"'. There are a number of use cases where this capability can
 be extremely useful. Common ones might be adding a date that a property was last
@@ -1944,20 +1939,15 @@ a date or ACL information to individual properties.
 Using 'unfold' and 'WithOptions' with Meta Properties
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A new feature was introduced in Apache TinkerPop version 3.4 that allows us to more
-easily include both properties and their meta properties in the result from a
-'valueMap' step that follows a 'properties' step.
-
+There is an easy way to include both properties and their meta properties in the
+result from a 'valueMap' step that follows a 'properties' step. Using this capability
+requires that the graph database you are using has support for meta properties. The
+examples below build upon the examples shown in the previous section.
 
 TIP: All of the possible values that can be specified using WithOptions can be found
 in the official Apache TinkerPop JavaDoc documentation
 http://tinkerpop.apache.org/javadocs/current/full/org/apache/tinkerpop/gremlin/process/traversal/step/util/WithOptions.html[at
 this location].
-
-To use this new capability
-requires that the graph database you are using has support for both meta properties
-and TinkerPop version 3.4. The examples below build upon the examples shown in the
-previous section.
 
 First of all, we know how to inspect the properties present for any vertex using the
 'properties' step.
@@ -4550,7 +4540,7 @@ Using regular expressions to do fuzzy searches
 
 Let's take a look at one case where use of closures might be helpful. It is a
 common requirement when working with any kind of database to want to do some
-sort of fuzzy text search or even to search using a regular expression. TinkerPop 3
+sort of fuzzy text search or even to search using a regular expression. TinkerPop
 itself does not provide direct support for this. In other words there
 currently is no sophisticated text search method beyond the basic 'has()' type steps
 we have looked at above. However, the underlying graph store can still expose
@@ -4690,135 +4680,17 @@ regex = {new P(bp, it)}
 g.V().has('desc', regex(/^Dal.*/)).values('desc')
 ----
 
-[[vmunroll]]
-Unrolling the lists returned by 'valueMap'
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-In the "<<tp34vm>>" section, I showed some examples that used 'by(unfold())' following
-a 'valueMap' step unroll property values. As you may recall, this means that single
-property values are not returned wrapped inside lists. This feature was introduced in
-TinkerPop 3.4. However, you can achieve the same results using earlier versions of
-TinkerPop, it just takes a bit more work.
-
-In case you jumped ahead to this section, here is an example of the new feature and
-the output it produces.
-
-[source,groovy]
-----
-g.V().has('code','SFO').valueMap().by(unfold()).unfold()
-
-country=US
-code=SFO
-longest=11870
-city=San Francisco
-elev=13
-icao=KSFO
-lon=-122.375
-type=airport
-region=US-CA
-runways=4
-lat=37.6189994812012
-desc=San Francisco International Airport
-----
-
-We could use a query like the one below to achieve the same result. A 'map' step is
-used to unpackage and then repackage the results of the 'valueMap' step with the
-values unrolled from their lists.
-
-[source,groovy]
-----
-g.V().has('code','SFO').
-      valueMap().
-      map(unfold().group().by(keys).by(select(values).unfold())).
-      unfold()
-----
-
-The output looks just like that from the prior query, which is good. However, there
-is still an issue with the query. It will not do quite what we want if any property
-has a list or set of values associated with it.
-
-[source,groovy]
-----
-country=US
-code=SFO
-longest=11870
-city=San Francisco
-elev=13
-icao=KSFO
-lon=-122.375
-type=airport
-region=US-CA
-runways=4
-lat=37.6189994812012
-desc=San Francisco International Airport
-----
-
-Let's imagine we wanted to add an additional region classification of "Bay Area" to
-the San Francisco airport vertex. We might do that as shown below.
-
-[source,groovy]
-----
-g.V().has('code','SFO').property(list,'region','Bay Area')
-----
-
-We can look at the valueMap for the 'region' property to validate we now have a list.
-
-[source,groovy]
-----
-g.V().has('code','SFO').valueMap('region')
-
-[region:[US-CA,Bay Area]]
-----
-If we were to use the 'map' step that we just created, it would try to unroll this
-property which in this case is not what we want as we want to preserve the list. We
-can modify this a little to include a 'choose' step that only unrolls the
-list if it has a length of one.
-
-[source,groovy]
-----
-g.V().has('code','SFO').
-      valueMap().
-      map(unfold().
-        group().
-          by(keys).
-          by(choose(select(values).count(local).is(1),
-                    select(values).unfold(),
-                    select(values)))).
-      unfold()
-----
-
-This time the results are still unrolled except for the 'region' property which
-remained a list.
-
-[source,groovy]
-----
-country=US
-code=SFO
-longest=11870
-city=San Francisco
-elev=13
-icao=KSFO
-lon=-122.375
-type=airport
-region=[US-CA, Bay Area]
-runways=4
-lat=37.6189994812012
-desc=San Francisco International Airport
-----
-
-
-
 [[graphvars]]
 Using graph variables to associate metadata with a graph
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-TinkerPop 3 introduced the concept of graph variables. A graph variable is a
-key/value pair that can be associated with the graph itself. Graph variables are not
-considered part of the graph that you would process with Gremlin traversals but are
-in essence a way to associate metadata with a graph. You can set and retrieve graph
-variables using the 'variables' method of the graph object. Let's assume I wanted to
-add some metadata that allowed me to record who the maintainer of the 'air-routes'
-graph is and when it was last updated. We could do that as follows.
+A graph variable is a key/value pair that can be associated with the graph itself.
+Graph variables are not considered part of the graph that you would process with
+Gremlin traversals but are in essence a way to associate metadata with a graph.
+You can set and retrieve graph variables using the 'variables' method of the graph
+object. Let's assume I wanted to add some metadata that allowed me to record who
+the maintainer of the 'air-routes' graph is and when it was last updated. We could
+do that as follows.
 
 [source,groovy]
 ----
@@ -5108,23 +4980,20 @@ topic. That documentation can be found at
 http://tinkerpop.apache.org/docs/current/reference/#_gremlin_i_o.
 
 There are currently three versions of GraphSON. The original 1.0 version and then
-versions 2.0 and 3.0 that added type information to the format. These were added in
-TinkerPop versions 3.2.2 and 3.3 respectively. The default format
+versions 2.0 and 3.0 that added type information to the format. The default format
 unless explicitly specified is currently GraphSON 3.0
-
 
 [[sav]]
 Saving (serializing) a graph as GraphML (XML) or GraphSON (JSON)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Using TinkerPop 3 you can save a graph either in GraphML or Graphson format. GraphML
-is an industry standard XML format for describing a graph and is recognized by many
-other applications such as Gephi. GraphSON was defined as part of the TinkerPop
-project and is less broadly supported outside of TinkerPop enabled tools and graphs.
+You can save a graph either in GraphML or Graphson format. GraphML is an industry
+standard XML format for describing a graph and is recognized by many other
+applications such as Gephi. GraphSON was defined as part of the TinkerPop project
+and is less broadly supported outside of TinkerPop enabled tools and graphs.
 However, whereas GraphML is considered lossee for some graphs (it does not support
-all of the data types and structures used by TinkerPop 3). GraphSON is not
+all of the data types and structures used by TinkerPop). GraphSON is not
 considered lossee.
-
 
 Saving a graph to a GraphML file can be done using the following Gremlin expression.
 You might want to try it on one of your graphs and look at the output generated. You
@@ -5140,7 +5009,7 @@ also beautify XML files well.
 graph.io(graphml()).writeGraph('my-graph.graphml')
 ----
 
-TinkerPop 3 offers two different JSON packaging options. These are not to be confused
+TinkerPop offers two different JSON packaging options. These are not to be confused
 with the three different syntax versions. The default encoding option  stores each
 vertex in a graph and all of its edges as a single JSON document. This is repeated
 for every vertex in the graph. This is essentially what is known as 'adjacency list'
@@ -5180,7 +5049,7 @@ fos = new FileOutputStream("my-graph.json")
 GraphSONWriter.build().wrapAdjacencyList(true).create().writeGraph(fos,graph)
 ----
 
-TIP: If you are ingesting large amounts of data into a TinkerPop 3 enabled graph, the
+TIP: If you are ingesting large amounts of data into a TinkerPop enabled graph, the
 unwrapped flavor of GraphSON is probably a much better choice than GraphML or wrapped
 GraphSON. Using this format you can stream data into a graph one vertex at a time
 rather than having to try and send the entire graph as a potentially huge JSON file
@@ -5219,7 +5088,7 @@ a GraphSON JSON format file.
 
 
 The only difference between loading a GraphML file or a GraphSON file is in the name
-of the method from the IoCore Tinkerpop 3 class that we use. When we want to load
+of the method from the IoCore Tinkerpop class that we use. When we want to load
 a graphML file we specify 'IoCore.graphml()'.
 
 [source,groovy]
@@ -5262,12 +5131,11 @@ regular Gremlin Console and a TinkerGraph on your laptop. You do not need to be
 connected to a Gremlin Server to use the examples that I am about to present.
 
 The first thing you need to do is create an instance of a GraphSON mapper that can be
-used to generate JSON for us from a query result. Note that since TinkerPop 3.2.2 there
-have been multiple versions of the GraphSON format. The original 1.0 version did not
-contain any type information. Version 2.0 introduced the concept of including data
-types within the JSON. As part of TinkerPop 3.3 GraphSON 3.0 was introduced to add a
-few additional types. All three formats are still supported. The default is now
-GraphSON 3.0.
+used to generate JSON for us from a query result. Thereare  multiple versions of the
+GraphSON format. The original 1.0 version did not contain any type information.
+Version 2.0 introduced the concept of including data types within the JSON. Version
+3.0 was introduced to add a few additional types. All three formats are still
+supported. The default is now GraphSON 3.0.
 
 The example below creates a 'GraphSONMapper' object that will generate GraphSON 1.0
 format JSON.

--- a/book/Section-Common-Serialization-Formats.adoc
+++ b/book/Section-Common-Serialization-Formats.adoc
@@ -267,12 +267,11 @@ To be written
 GraphSON
 ~~~~~~~~
 
-As discussed in the "<<graphmlandjsonintro>>" section, since TinkerPop 3.2.2 there
-have been multiple versions of the GraphSON format. The original 1.0 version did not
-contain any type information. Version 2.0 introduced the concept of including data
-types within the JSON. As part of TinkerPop 3.3 GraphSON 3.0 was introduced to add a
-few additional types. All three formats are still supported. The default is now
-GraphSON 3.0.
+As discussed in the "<<graphmlandjsonintro>>" section, there are multiple versions of
+the GraphSON format. The original 1.0 version did not contain any type information.
+Version 2.0 introduced the concept of including data types within the JSON and
+GraphSON 3.0 introduced a few additional types. All three formats are still
+supported. The default is now GraphSON 3.0.
 
 To be written
 

--- a/book/Section-Getting-Started.adoc
+++ b/book/Section-Getting-Started.adoc
@@ -48,7 +48,7 @@ Any such TinkerPop enabled graph databases can be accessed using the Gremlin que
 language and corresponding API. We can also use the TinkerPop API to write client
 code in languages like Java that can talk to a TinkerPop enabled graph. For most of
 this book we will be working within the Gremlin console with a local graph. However
-in Chapter 6 we will take a look at Gremlin Server and some other TinkerPop 3 enabled
+in Chapter 6 we will take a look at Gremlin Server and some other TinkerPop enabled
 environments. Most of Apache Tinkerpop has been developed using Java 8 but there are
 also bindings available for many other programming languages such as Groovy and
 Python. Parts of TinkerPop are themselves developed in Groovy, most notably the
@@ -59,7 +59,7 @@ Gremlin Server. All of these topics are covered in detail in this book.
 The queries used as examples in this book have been tested with Apache TinkerPop
 version {tpvercheck} as well as many prior releases. Tests were performed using the
 TinkerGraph in memory graph and the Gremlin console, as well as
-other TinkerPop 3 enabled graph stores.
+other TinkerPop enabled graph stores.
 
 [[gconsole]]
 The Gremlin console
@@ -74,7 +74,7 @@ console can actually work with graphs that are running locally or remotely but f
 the majority of this book we will keep things simple and focus on local graphs.
 
 To follow along with this tutorial you will need to have installed the Gremlin
-console or have access to a TinkerPop3/Gremlin enabled graph store such as
+console or have access to a TinkerPop/Gremlin enabled graph store such as
 TinkerGraph or JanusGraph.
 
 Regardless of the environment you use, if you work with Apache TinkerPop enabled
@@ -89,7 +89,7 @@ You can download the Gremlin console from the official Apache TinkerPop website:
 http://tinkerpop.apache.org/
 
 It only takes a few minutes to get the Gremlin Console installed and running. You
-just download the ZIP file and 'unzip' it and you are all set. TinkerPop 3 also
+just download the ZIP file and 'unzip' it and you are all set. TinkerPop also
 requires a recent version of Java 8 being installed. I have done all of my testing
 using Java 8 version 1.8.0_131. The Gremlin Console will not work with versions prior
 to 1.8.0_45. If you do not have Java 8 installed it is easy to find and download off
@@ -238,7 +238,7 @@ the following command from inside the Gremlin console.
 ----
 // What version of Gremlin console am I running?
 gremlin>  Gremlin.version()
-==>3.4.10
+==>3.7.0
 ----
 
 One thing that is not at all obvious or apparent is that the Gremlin console quietly
@@ -299,16 +299,17 @@ in help.
 Introducing TinkerGraph
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-As well as the Gremlin Console, the TinkerPop 3 download includes an implementation
+As well as the Gremlin Console, the TinkerPop download includes an implementation
 of an in-memory graph store called TinkerGraph. This book was mostly developed
 using TinkerGraph but I also tested everything using JanusGraph. I will introduce
 JanusGraph later in the "<<janusintro>>" section. The nice thing about TinkerGraph
 is that for learning and testing things you can run everything you need on your
-laptop or desktop computer and be up and running very quickly. I will also explain how to
-get started with the Gremlin Console and TinkerGraph a bit later in this section.
+laptop or desktop computer and be up and running very quickly. I will also explain
+how to get started with the Gremlin Console and TinkerGraph a bit later in this
+section.
 
-Tinkerpop 3 defines a number of capabilities that a graph store should support. Some
-are optional others are not. If supported, you can query any TinkerPop 3 enabled
+Tinkerpop defines a number of capabilities that a graph store should support. Some
+are optional others are not. If supported, you can query any TinkerPop enabled
 graph store to see which features are supported using a command such as
 'graph.features()' once you have established the 'graph' object. We will look at how
 to do that soon. The following list shows the features supported by TinkerGraph. This
@@ -612,102 +613,6 @@ set available. That file can be found in the 'sample-data' folder. Look for a fi
 called `air-routes-latest.graphml`. There is also a README file to go along with the
 updated data set called `README-air-routes-latest.txt` in the same folder.
 
-
-[[mn]]
-TinkerPop 3 migration notes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-There are still a large number of examples on the internet that show the TinkerPop 2
-way of doing things. Quite a lot of things changed between TinkerPop 2 and TinkerPop
-3. If you were an early adopter and are coming from a TinkerPop 2 environment to a
-TinkerPop 3 environment you may find some of the tips in this section helpful. As
-explained below, using the 'sugar' plugin will make the migration from TinkerPop 2
-easier but it is recommended to learn the full TinkerPop 3 Gremlin syntax and get
-used to using that as soon as possible. Using the full syntax will make your queries
-a lot more portable to other TinkerPop 3 enabled graph systems.
-
-TinkerPop 3 requires a minimum of Java 8 v45. It will not run on earlier versions of
-Java 8 based on my testing.
-
-[[cr]]
-Creating a TinkerGraph TP2 vs TP3
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The way that you create a TinkerGraph changed between TinkerPop 2 and 3.
-[source,groovy]
-----
-graph = new TinkerGraph()  // TinkerPop 2
-graph = TinkerGraph.open() // TinkerPop 3
-----
-
-[[ld2]]
-Loading a graphML file TP2 vs TP3
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If you have previous experience with TinkerPop 2 you may also have noticed that the
-way a graph is loaded has changed in TinkerPop 3.
-
-[source,groovy]
-----
-graph.loadGraphML('air-routes.graphml') // TinkerPop 2
-graph.io(graphml()).readGraph('air-routes.graphml') // TinkerPop 3
-----
-
-The Gremlin language itself changed quite a bit between TinkerPop 2 and TinkerPop 3.
-The remainder of this book only shows TinkerPop 3 examples.
-
-[[sugarplugin]]
-A word about the TinkerPop.sugar plugin
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The Gremlin console has a set of plug in modules that can be independently enabled or
-disabled. Depending upon your use case you may or may not need to manage plugins.
-
-TinkerPop 2 supported by default some syntactic 'sugar' that allowed shorthand
-forms of queries to be entered when using the Gremlin console. In TinkerPop 3 that
-support has been moved to a plugin and is off by default. It has to be enabled if you
-want to continue to use the same shortcuts that TinkerPop 2 allowed by default.
-
-You can enable 'sugar' support from the Gremlin console as follows:
-
-[source,groovy]
-----
-:plugin use tinkerpop.sugar
-----
-
-TIP: The Gremlin Console remembers which plugins are enabled between restarts.
-
-In the current revision of this book I have tried to remove any dependence on the
-'TinkerPop.sugar' plugin from the examples presented. By not using Sugar, queries
-shown in this book should port very easily to other TinkerPop 3 enabled graph
-platforms. A few of the queries may not work on versions of TinkerPop prior to 3.2 as
-TinkerPop continues to evolve and new features are being added fairly regularly.
-
-The 'Tinkerpop.sugar' plugin allows some queries to be expressed in a more shorthand
-or lazy form, often leaving out references to 'values()' and leaving out parenthesis.
-For example:
-
-[source,groovy]
-----
-// With Sugar enabled
-g.V.hasLabel('airport').code
-
-// Without Sugar enabled
-g.V().hasLabel('airport').values('code')
-----
-
-People Migrating from TinkerPop 2 will find the Sugar plugin helps get your existing
-queries running more easily but as a general rule it is recommended to become
-familiar with the longhand way of writing queries as that will enable your queries to
-run as efficiently as possible on graph stores that support TinkerPop 3. Also, due to
-changes introduced with TinkerPop 3, using sugar will not be as performant as using
-the normal Gremlin syntax.
-
-NOTE: _In earlier versions of this book many of the examples showed the 'sugar'
-form. In the current revision I have tried to remove all use of that form. It's
-possible that I may have missed a few and I will continue to check for, and fix, any
-that got missed. Please let me know if you find any that slipped through the net!_
-
 [[ld]]
 Loading the air-routes graph using the Gremlin console
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -723,12 +628,11 @@ commands shown below, available in the `/sample-data` directory.
 https://github.com/krlawrence/graph/tree/master/sample-data
 
 These commands create an in-memory TinkerGraph which will use LONG values for the
-vertex, edge and vertex property IDs. TinkerPop 3 introduced the concept of a
-'traversal' so as part of loading a 'graph' we also setup a graph traversal source
-object called 'g' which we will then refer to in our subsequent queries of the graph.
-The 'max-iteration' option tells the Gremlin console the maximum number of lines of
-output that we ever want to see in return from a query. The default, if this is not
-specified, is 100.
+vertex, edge and vertex property IDs. As part of loading a 'graph' we need to setup
+a graph traversal source object called 'g' which we will then refer to in our
+subsequent queries of the graph. The 'max-iteration' option tells the Gremlin
+console the maximum number of lines of output that we ever want to see in return
+from a query. The default, if this is not specified, is 100.
 
 TIP: You can use the 'max-iteration' setting to control how much output the Gremlin
 Console displays.

--- a/book/Section-Introduction.adoc
+++ b/book/Section-Introduction.adoc
@@ -89,7 +89,7 @@ it is about continues to evolve. Your help and support is very much appreciated.
 What is this book about?
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-This book introduces the Apache TinkerPop 3 'Gremlin' graph query and traversal
+This book introduces the Apache TinkerPop 'Gremlin' graph query and traversal
 language via real examples featuring real-world graph data. That data along with
 sample code and example applications is available for download from the GitHub
 project as well as many other items. The graph, 'air-routes', is a model of
@@ -103,15 +103,14 @@ NOTE: The examples in this book have been tested using Apache TinkerPop release
 that release to the book.
 
 TinkerGraph is an 'in-memory' graph, meaning nothing gets saved to disk
-automatically. It is shipped as part of the Apache TinkerPop 3 download. The
-goal of this tutorial is to allow someone with little to no prior knowledge to
-get up and going quickly using the Gremlin console and the 'air-routes' graph.
-Later in the book I will discuss using additional technologies such as
-JanusGraph, Apache Cassandra, Gremlin Server and Elasticsearch to build
-scalable and persisted graph stores that can still be traversed using Gremlin
-queries. I will also discuss writing standalone Java and Groovy applications
-as well as using the Gremlin Console. I even slipped a couple of Ruby examples in
-too!
+automatically. It is shipped as part of the Apache TinkerPop download. The goal of
+this tutorial is to allow someone with little to no prior knowledge to get up and
+going quickly using the Gremlin console and the 'air-routes' graph. Later in the
+book I will discuss using additional technologies such as JanusGraph, Apache
+Cassandra, Gremlin Server and Elasticsearch to build scalable and persisted graph
+stores that can still be traversed using Gremlin queries. I will also discuss
+writing standalone Java and Groovy applications as well as using the Gremlin
+Console. I even slipped a couple of Ruby examples in too!
 
 NOTE: In the first few sections of this book I have mainly focussed on
 showing the different types of queries that you can issue using Gremlin. I have not
@@ -165,8 +164,8 @@ evolved, it has become a lot more common to connect to a graph remotely via a
 Gremlin Server.
 Chapter 8 - COMMON GRAPH SERIALIZATION FORMATS::
 - In Chapter eight a discussion is presented of some common Graph serialization file
-formats along with coverage of how to use them in the context of TinkerPop 3
-enabled graphs.
+formats along with coverage of how to use them in the context of TinkerPop enabled
+graphs.
 Chapter 9 - FURTHER READING::
 - I finish up by providing several links to useful web sites where you can find
 tools and documentation for many of the topics and technologies covered in this book.

--- a/book/Section-Miscellaneous-Queries-Results.adoc
+++ b/book/Section-Miscellaneous-Queries-Results.adoc
@@ -2025,9 +2025,8 @@ Here are the results again, this time sorted by route distance in descending ord
 [DOH,8287,LAX]     [DFW,8022,DXB]
 ----
 
-As part of the TinkerPop 3.2.3 release an additional capability was added to the
-'where' step that allows it to be followed by a 'by' modulator. This allows us,
-should we so desire, to simplify our query a bit more as follows.
+The 'where' step can be followed by a 'by' modulator. This allows us, should we so
+desire, to simplify our query a bit more as follows.
 
 [source,groovy]
 ----
@@ -2039,10 +2038,11 @@ g.V().as('s').
       path().by('code').by('dist')
 ----
 
-As you can see, we got the same results from our modified query. Well, almost the same
-results! Notice that we actually got the 'return routes' returned. So for example,
-we got the route from DXB to AKL and not the route from AKL to DXB that we got in the
-prior case. This is because we compared the values in the opposite order!
+As you can see, we got the same results from our modified query. Well, almost the
+same results! Notice that we actually got the 'return routes' returned. So for
+example, we got the route from DXB to AKL and not the route from AKL to DXB that
+we got in the prior case. This is because we compared the values in the opposite
+order!
 
 [source,groovy]
 ----
@@ -2433,11 +2433,6 @@ parameter. Running the query will produce the following results:
 [AUS, 142,  IAH, 4820, LHR, 4962]
 ----
 
-NOTE: In Tinkerpop 3.3 the syntax of 'sack' was changed. Where previously you would
-write something like 'sack(sum,''runways'')' you are now required to write
-'sack(sum).by(''runways'')'. The prior format was already deprecated in Tinkerpop
-3.2.5 but is now fully removed starting with Tinkerpop 3.3.
-
 We could add a little post processing to our query to only output the airport codes
 and the total mileage. Given this is post processing of a small data set, using a bit
 of in-line code does not feel too ugly here.
@@ -2519,8 +2514,8 @@ sacks in powerful ways to store data as your query iterates.
 
 [source,groovy]
 ----
-// The same query but done using the new sack() step in TinkerPop 3
-// shown as an example only. The prior query works just fine for this.
+// The same query but done using the sack() step in TinkerPop shown as an
+// example only. The prior query works just fine for this.
 
 g.withSack([:]).
   V().hasLabel('airport').

--- a/book/Section-Moving-Beyond.adoc
+++ b/book/Section-Moving-Beyond.adoc
@@ -45,7 +45,7 @@ from within the Gremlin Console. As you start to create more sophisticated
 applications you will find that the Gremlin Console is just one of the tools you will
 need to have available in your toolbox. It is very likely, if not certain, that you
 will want to write standalone applications that can work with a graph. There are a
-number of different language bindings currently available for TinkerPop 3. One of the
+number of different language bindings currently available for TinkerPop. One of the
 most widely used is the Java API. Apache TinkerPop itself is coded in Java.
 
 NOTE: You will find several Java samples at the GitHub repository associated with
@@ -393,22 +393,13 @@ which is part of the 'VertexProperty' interface.
 When local scope needs to be specified as a parameter of sort order direction needs
 to be specified the statics defined in the  'Scope' and 'Order' Enums can be used.
 
-NOTE: The 'Order.incr' and 'Order.decr' enumerations were deprecated in the TinkerPop
-3.3.4 release in favor of 'Order.asc' and 'Order.desc' to bring the keywords more
-into line with other commonly used query languages. As of TinkerPop 3.5.0, 'incr' and
-'decr' were removed from the Gremlin query language altogether.
-
 .Scope and ordering
 [cols="1,1,3"]
 |==============================================================================
 |local   | Scope.local    | order(Scope.local)
 |global  | Scope.global   | order(Scope.global)
 |desc    | Order.desc     | order().by(Order.desc)
-|decr    | Order.decr     | order().by(Order.decr)  [Deprecated since 3.3.4, removed
-in 3.5.0]
 |asc     | Order.asc      | order().by(Order.asc)
-|incr    | Order.incr     | order().by(Order.incr)  [Deprecated since 3.3.4, removed
-in 3.5.0]
 |shuffle | Order.shuffle  | order().by(Order.shuffle)
 |==============================================================================
 
@@ -467,8 +458,7 @@ defined in the 'P' class. Not all the methods defined are shown below.
 |between | P.between      | has("runways",P.between(2,5))
 |==============================================================================
 
-The Apache TinkerPop release 3.4 introduced some new text predicates and a new TextP
-class.
+The 'TextP' class exposes text search based predicates.
 
 .Text Predicates
 [cols="1,1,3"]
@@ -541,14 +531,7 @@ The 'Pick' Enum defines constants that are used in association with the 'branch'
 Another useful tip, that was shared on the Gremlin Users mailing list, is that you
 can ask the Gremlin Console to show you a list of everything that has been imported
 on your behalf "behind the scenes" using the command ':show imports'. What might
-typically be returned is shown below. I included a version check in the output so in
-case this changes in the future you can see which version of Gremlin I queried.
-
-[source,groovy]
-----
-gremlin> Gremlin.version
-==>3.4.10
-----
+typically be returned is shown below and may change from version to version.
 
 Here is the list of imports that the Gremlin Console has setup for us quietly behind
 the scenes when we started it. Take particular note of the ones that are 'static'
@@ -968,7 +951,7 @@ https://github.com/krlawrence/graph/tree/master/sample-code.
 It is assumed that you have downloaded and installed Groovy for your environment and
 have set the PATH to point to wherever the Groovy binaries are located. Just as in
 the Java example, the first thing we need to do is pull in via 'import' all of the
-TinkerPop 3 classes that our program will use.
+TinkerPop classes that our program will use.
 
 [source,groovy]
 ----
@@ -1092,7 +1075,7 @@ And here is the sort of output we should get back.
 
 [source,groovy]
 ----
-Gremlin version is 3.3.1
+Gremlin version is 3.7.0
 Loading the air-routes graph...
 
 [country:[US], code:[AUS], longest:[12250], city:[Austin], elev:[542], icao:[KAUS], lon:[-97.6698989868164], type:[airport], region:[US-TX], runways:[2], lat:[30.1944999694824], desc:[Austin Bergstrom International Airport]]

--- a/book/Section-Writing-Gremlin-Queries.adoc
+++ b/book/Section-Writing-Gremlin-Queries.adoc
@@ -219,7 +219,7 @@ have not tried to teach every possible usage of every Gremlin step and method,
 rather, I have tried to provide a good and approachable foundation in writing many
 different types of Gremlin query using an interesting and real-world graph.
 
-NOTE: The latest TinkerPop 3 documentation is always available at this URL:
+NOTE: The latest TinkerPop documentation is always available at this URL:
 http://tinkerpop.apache.org/docs/current/reference/
 
 Below are some simple queries against the 'air-routes' graph to get us started. It is
@@ -836,8 +836,8 @@ g.V(3).out().limit(5).path().by(out().count())
 [[pathfromto]]
 Modifying a 'path' using 'from' and 'to' modulators
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In Apache TinkerPop version 3.2.5 the ability to limit what is returned by the 'path'
-step using 'from' and 'to' modulators was added. This enables us to not return the
+
+The 'from' and 'to' modulators for the 'path' step enables us to not return the
 entire path of a traversal but instead to be more selective.
 
 First of all, look at the example below. In this case I have just used the same
@@ -1040,11 +1040,10 @@ Using 'as', 'select' and 'project' to refer to traversal steps
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Sometimes it is useful to be able to remember a point of a traversal by giving it a
-name (label) and refer to it later on in the same query. This ability was more
-essential in TinkerPop 2 than it is in TinkerPop 3 but it still has many uses. The
-query below uses an 'as' step to attach a label at two different parts of the
-traversal, each representing different vertices that were found. A 'select' step is
-later used to refer back to them.
+name (label) and refer to it later on in the same query. The query below uses an
+'as' step to attach a label at two different parts of the traversal, each
+representing different vertices that were found. A 'select' step is later used to
+refer back to them.
 
 [source,groovy]
 ----
@@ -1527,9 +1526,9 @@ airports will most likely come back in the order they are put into the graph. Th
 not likely to be the case with other graph stores such as JanusGraph. So do not rely
 on any sort of expectation of order when using 'range' to process sets of vertices.
 
-In TinkerPop 3.3 a new 'skip' step was introduced which can be used as an alternative
-to 'range' in some cases. The 'skip' step can be used whenever you would otherwise
-use 'range' where the second parameter would be '-1' meaning "all remaining".
+You can use 'skip' step as an alternative to 'range' in some cases. The 'skip'
+step can be used whenever you would otherwise use 'range' where the second
+parameter would be '-1' meaning "all remaining".
 
 The two examples below will produce the same results.
 
@@ -1700,9 +1699,7 @@ desc=[Austin Bergstrom International Airport]
 NOTE: Notice how each key, like 'country', is followed by a value that is returned as
 an element of a list. This is because it is possible (for vertices but not for edges)
 to provide more than one property value for a given key by encoding them as a list or
-as a set. In the Apache TinkerPop release 3.4 some changes were introduced to make
-it easier to control how these results are returned. Those changes are discussed in
-the next section.
+as a set. We discuss how to better control this output in the paragraphs that follow.
 
 Here are some more examples of how 'valueMap' can be used. If a parameter of 'true'
 is provided, then the results returned will include the ID and label of the element
@@ -1786,22 +1783,12 @@ g.E(5161).valueMap(true)
 [id:5161,dist:1357,label:route]
 ----
 
-[[tp34vm]]
-Changes to 'valueMap' introduced in TinkerPop 3.4
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+There are other ways to control the results that a 'valueMap' step return using
+the 'with()' modulator.
 
-Starting with the Apache TinkerPop 3.4 release, a few changes have been introduced
-that allow easier control of the results that a 'valueMap' step returns. Further, the
-use of 'true' to return the ID and label properties of a Vertex or an Edge was
-deprecated and replaced by the use of a 'with' modulator.
-
-NOTE: The new valueMap configuration options are described in the official
+NOTE: The valueMap configuration options are described in the official
 documentation at the following link
 http://tinkerpop.apache.org/docs/current/reference/#valuemap-step.
-
-The previous ways of using 'valueMap' will still work but over time as Graph DB
-providers adopt TinkerPop 3.4 the examples shown below will become the preferred way
-of controlling the results returned by 'valueMap'.
 
 Instead of using 'valueMap(true)' to include the ID and label of an element (a vertex
 or an edge) in the results, the new 'with(WithOptions.tokens)' construct can
@@ -1872,14 +1859,8 @@ As discussed in the previous section, the property values returned by 'valueMap'
 by default represented as lists even if there is only a single property value
 present.
 
-NOTE: Using versions of TinkerPop prior to 3.4 it is still possible to generate the
-same unrolled results that you get using 'by(unfold())'. How to do that is discussed
-a bit later in the book we need to look at a few other steps such as 'map' first.
-If you want to jump ahead you will find these examples in the "<<vmunroll>>" section.
-
-Starting with TinkerPop 3.4 you can very easily request that these values be returned
-as single values not wrapped in lists. This can be done using a 'by' step modulator
-as shown below.
+You can very easily request that these values be returned as single values not
+wrapped in lists. This can be done using a 'by' step modulator as shown below.
 
 [source,groovy]
 ----
@@ -1915,16 +1896,10 @@ part of the "<<tp34vmmetaprop>>" section.
 An alternative to 'valueMap' - introducing 'elementMap'
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A new step, 'elementMap', was added to the Gremlin language as part of the Apache
-TinkerPop 3.4.4 release in October 2019. This new step is similar in many ways
-to the 'valueMap' step but makes some things a little easier.
-
-TIP: Make sure the graph database you are using has support for Apache TinkerPop
-at the 3.4.4 level or higher before using 'elementMap' in your queries.
-
-When using 'valueMap' you need to explicitly request that the ID and label of a
-vertex or an edge are included in query results. This is not necessary when
-using 'elementMap'.
+The 'elementMap' step is similar in many ways to the 'valueMap' step but makes
+some things a little easier. When using 'valueMap' you need to explicitly request
+that the ID and label of a vertex or an edge are included in query results. This
+is not necessary when using 'elementMap'.
 
 [source,groovy]
 ----
@@ -2639,17 +2614,10 @@ g.V().hasLabel('airport').values('longest').min()
 ----
 
 It is also possible in more recent versions of Apache TinkerPop to use the 'min' and
-'max' steps with more than just numeric values.
-
-NOTE: Before TinkerPop 3.4 was released 'min' and 'max' could only be used with
-numeric values. It is now possible to also test any values that are considered
-_"comparable"_.
-
-Prior to TinkerPop 3.4, it was only possible to work with purely
-numeric values when using 'min' and 'max'. It is now possible to apply these steps to
-any values that are considered _"comparable"_. So, for example, we can now compare
-strings as well as numbers. The examples below look for the minimum and maximum value
-in the descriptive names of the continents.
+'max' steps with more than just numeric values. These steps apply to any value
+that are considered _"comparable"_. So, for example, we can now compare strings as
+well as numbers. The examples below look for the minimum and maximum value in the
+descriptive names of the continents.
 
 [source,groovy]
 ----
@@ -2658,20 +2626,6 @@ g.V().hasLabel('continent').values('desc').min()
 Africa
 
 g.V().hasLabel('continent').values('desc').max()
-
-South America
-----
-
-Prior to TinkerPop 3.4, a similar result could still be achieved by ordering the
-results and simply returning the first one.
-
-[source,groovy]
-----
-g.V().hasLabel('continent').values('desc').order().limit(1)
-
-Africa
-
-g.V().hasLabel('continent').values('desc').order().by(desc).limit(1)
 
 South America
 ----
@@ -3309,19 +3263,16 @@ OSR
 ----
 
 [[textpredicates]]
-New text search predicates added in TinkerPop 3.4
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Text search predicates
+~~~~~~~~~~~~~~~~~~~~~~
 
-Probably one of, if not the, most anticipated features in Apache TinkerPop version
-3.4 was the addition of new '"predicates"' that aid in performing more focused text
-searches.
+Among the '"predicates"' Gremlin has available are the ones used in performing more
+focused text searches. There are three predicates that search for the existence of
+one or more characters within a string of text and three that search for the non
+existence of one or more characters.
 
 TIP: Additional information on the text predicates can be found in the official
 Apache TinkerPop documentation here: http://tinkerpop.apache.org/docs/current/reference/#a-note-on-predicates
-
-In total, six new predicates were added to the Gremlin query language. There are
-three predicates that search for the existence of one or more characters within a
-string of text and three that search for the non existence of one or more characters.
 
 .Text searching predicates
 [cols="^1,4"]
@@ -3685,7 +3636,6 @@ above sea level. Aircraft need a lot more runway to operate safely at that altit
 [country:[CN], code:[BPX], longest:[18045], city:[Bangda], elev:[14219], icao:[ZUBD], lon:[97.1082992553711], type:[airport], region:[CN-54], runways:[1], lat:[30.5536003112793], desc:[Qamdo Bangda Airport]]
 ----
 
-
 [[sortkeyvalue]]
 Sorting by key or value
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -3694,10 +3644,6 @@ Sometimes, when the results of a query are a set of one or more key:value pairs,
 need to sort by either the key or the value in either ascending or descending order.
 Gremlin offers us ways that we can control the sort in these cases. Examples of how
 this works are shown below.
-
-NOTE: In Tinkerpop 3.3 changes to the syntax were made. The previous keywords
-'valueDecr', 'valueIncr', 'keyDecr' and 'keyIncr' are now specified using the form
-'by(keys,asc)' or 'by(values,desc)' etc.
 
 The following example shows the difference between running a query with and without
 the use of 'order' to sort using the keys of the map created by the 'group' step.
@@ -3736,139 +3682,6 @@ g.V().hasLabel('airport').limit(10).
 
 [7:[DFW],6:[BOS],5:[ATL],4:[BNA,IAD],3:[ANC,BWI,DCA],2:[AUS,FLL]]
 ----
-
-[[orderchanges]]
-Changes to 'order' introduced in TinkerPop release 3.3.4
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-On October 15th 2018 a change was introduced as part of the Apache TinkerPop 3.3.4
-release This change deprecated the 'incr' and 'decr' keywords recognized by the
-'order' step in favor of the, new at the time, 'asc' and 'desc' keywords. This book
-and its accompanying code samples have been updated to only use 'asc' and 'desc'. If
-the database you are using supports a version of Apache TinkerPop at the 3.3.4 level
-or higher you should be using the new keywords.
-
-NOTE: The 'Order.incr' and 'Order.decr' enumerations were deprecated in the TinkerPop
-3.3.4 release in favor of 'Order.asc' and 'Order.desc'. This was done bring the
-keywords more into line with other commonly used query languages. As of TinkerPop
-release 3.5.0, those enumerations were completely removed from the Gremlin reference
-implementation and documentation and should no longer be used.
-
-Let's take a look at how queries are affected by these changes. The query below
-finds the 10 airports in England with the most outgoing routes and sorts the results
-in descending order. Prior to TinkerPop 3.3.4 the query would have been written as
-follows.
-
-[source,groovy]
-----
-g.V().has('airport','region','GB-ENG').
-      order().by(out().count(),decr).limit(10).
-      project('a','b').by('code').by(out().count())
-----
-
-Running the query produces the following results.
-
-[source,groovy]
-----
-[a:LGW,b:200]
-[a:LHR,b:191]
-[a:STN,b:186]
-[a:MAN,b:182]
-[a:BHX,b:109]
-[a:LTN,b:104]
-[a:BRS,b:84]
-[a:EMA,b:64]
-[a:LBA,b:62]
-[a:LPL,b:60]
-----
-
-Using the new keywords introduced in the 3.3.4 release, the query can be written as
-shown below.
-
-[source,groovy]
-----
-g.V().has('airport','region','GB-ENG').
-      order().by(out().count(),desc).limit(10).
-      project('a','b').by('code').by(out().count())
-----
-
-The results produced, as you would expect, are the same as before.
-
-[source,groovy]
-----
-[a:LGW,b:200]
-[a:LHR,b:191]
-[a:STN,b:186]
-[a:MAN,b:182]
-[a:BHX,b:109]
-[a:LTN,b:104]
-[a:BRS,b:84]
-[a:EMA,b:64]
-[a:LBA,b:62]
-[a:LPL,b:60]
-----
-
-For completeness let's take a look at the same query but sorted in ascending order
-using both the original 'incr' keyword and the newly introduced 'asc' keyword. As
-with 'incr', this remains the default behavior if neither 'asc' nor 'desc' is
-specified.
-
-
-[source,groovy]
-----
-g.V().has('airport','region','GB-ENG').
-      order().by(out().count(),incr).limit(10).
-      project('a','b').by('code').by(out().count())
-----
-
-This time the query has found the airports with the least outgoing commercial
-aviation routes.
-
-[source,groovy]
-----
-[a:CVT,b:0]
-[a:GLO,b:1]
-[a:LEQ,b:1]
-[a:BZZ,b:1]
-[a:MME,b:2]
-[a:ISC,b:3]
-[a:HUY,b:6]
-[a:BLK,b:9]
-[a:NQY,b:11]
-[a:DSA,b:15]
-----
-
-The query below is modified to use the new 'asc' keyword.
-
-[source,groovy]
-----
-g.V().has('airport','region','GB-ENG').
-      order().by(out().count(),asc).limit(10).
-      project('a','b').by('code').by(out().count())
-----
-
-The results produced are the same as before.
-
-[source,groovy]
-----
-[a:CVT,b:0]
-[a:GLO,b:1]
-[a:LEQ,b:1]
-[a:BZZ,b:1]
-[a:MME,b:2]
-[a:ISC,b:3]
-[a:HUY,b:6]
-[a:BLK,b:9]
-[a:NQY,b:11]
-[a:DSA,b:15]
-----
-
-When TinkerPop 3.3.4 was released, these were not breaking changes. As more graph
-database engines move up to the TinkerPop 3.5.0 level these now become breaking
-changes and 'asc' and 'desc' must be used. In order for your code and other queries
-to be future proof, even if your database is not yet at the TinkerPop 3.5.0 level, I
-recommend making these changes to your code as soon as possible.
-
 
 [[bool]]
 Boolean operations
@@ -4247,17 +4060,12 @@ can be used.
 Using 'where' and 'by' to filter results
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A new capability was added in the Tinkerpop 3.2.4 release that allows a 'where' step
-to be followed with a 'by' modulator. This makes writing certain types of queries a
-lot easier than it was before. Hopefully by now, this capability is supported in many
-TinkerPop enabled graph stores but it is always a good idea to verify the version of
-TinkerPop supported before starting to design queries.
-
-The query below starts at the Austin airport and finds all the airports that you can
-fly to from there. A 'where' 'by' step is then used to filter the results to just
-those airports that have the same number of runways that Austin has. What is really
-nice about this is that we do not have to know ahead of time how many runways Austin
-itself has as that is handled for us by the query.
+A 'where' step can be followed with a 'by' modulator. The query below starts at the
+Austin airport and finds all the airports that you can fly to from there. A 'where'
+'by' step is then used to filter the results to just those airports that have the
+same number of runways that Austin has. What is really nice about this is that we
+do not have to know ahead of time how many runways Austin itself has as that is
+handled for us by the query.
 
 [source,groovy]
 ----
@@ -4619,18 +4427,13 @@ g.V().hasLabel('airport').limit(10).
 
 ----
 
-Starting with the 3.4.3 release of Apache TinkerPop, the 'option' step can now
-include a predicate. A nice improvement allowing additional comparisons to be made
-within the 'option' step. This allows testing that a value is greater than or less
-than another, for example, as part of the 'option' step without needing to write a
-more complex query.
+The 'option' step can also include a predicate, allowing more complex comparisons to
+be made as part of that 'choose'. This allows testing that a value is greater than
+or less than another, for example, as part of the 'option' step without needing to
+write a more complex query.
 
-NOTE:  In the TinkerPop 3.4.3 release, a feature was added allowing the 'option' step
-to include a predicate.
-
-Using this new capability, a query can be written using a more simple syntax. The
-query below creates a group containing the counts of airports that fall into one of
-the categories generated by the 'choose' and 'option' steps. Any airport situated
+The query below creates a group containing the counts of airports that fall into one
+of the categories generated by the 'choose' and 'option' steps. Any airport situated
 above 5,000 feet of elevation will be categorized as "high", greater than 3,000 feet
 as "medium" and all others as "low".
 
@@ -4646,32 +4449,15 @@ g.V().hasLabel('airport').
 [high:157,low:3013,medium:204]
 ----
 
-In TinkerPop releases prior to 3.4.3, the query could still have been written but it
-required the use of nested 'choose' steps.
-
-[source,groovy]
-----
-g.V().hasLabel('airport').
-      groupCount().
-        by(choose(values('elev').is(gt(5000)),
-             constant('high'),
-             choose(values('elev').is(gt(3000)),
-               constant('medium'),
-               constant('low'))))
-
-[high:157,low:3013,medium:204]
-----
-
 [[patmatch]]
 Using 'match' to do pattern matching
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The 'match' step was added in TinkerPop 3 and allows a more declarative style of
-pattern based query to be expressed using Gremlin. 'Match' can be a bit hard to
-master but once you figure it out it can be a very powerful way of traversing a graph
-looking for specific patterns. As we shall see however, sometimes a `where` step is
-more than adequate and can be used to express similar patterns to those supported by
-'match'.
+The 'match' step allows a more declarative style of pattern based query to be
+expressed using Gremlin. 'Match' can be a bit hard to master but once you figure it
+out it can be a very powerful way of traversing a graph looking for specific
+patterns. As we shall see however, sometimes a `where` step is more than adequate
+and can be used to express similar patterns to those supported by 'match'.
 
 Below is an example that uses 'match' to look for airline route patterns where there
 is a flight from one airport to another but no return flight back to the original
@@ -4806,8 +4592,7 @@ g.V().has('code','AUS').as('a').out().as('b').
 ----
 
 As mentioned in the "<<whereby>>" section, this query can be simplified further using
-a 'where' step and a 'by' modulator. This capability was introduced in the TinkerPop
-3.2.4 release.
+a 'where' step and a 'by' modulator.
 
 [source,groovy]
 ----
@@ -6085,10 +5870,11 @@ later.
 Nested and named 'repeat' steps
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Starting with Apache TinkerPop release 3.4 it is now possible to nest a 'repeat' step
-inside another 'repeat' step as well as inside 'emit' and 'until' steps.
+The 'repeat' step can be nested inside another 'repeat' step as well as inside 'emit'
+and 'until' steps.
 
-TIP: The official documentation for these new capabilities can be located here: http://tinkerpop.apache.org/docs/current/reference/#repeat-step
+TIP: The official documentation for these new capabilities can be located here:
+http://tinkerpop.apache.org/docs/current/reference/#repeat-step
 
 It is also possible to label a repeat step with a name so that it can be referenced
 later in a traversal. Nested 'repeat' steps allow for some interesting new graph
@@ -6657,8 +6443,7 @@ detail in the "<<mostroutes>>" section.
 ----
 
 The next query will calculate the route degree based on all, incoming and outgoing,
-routes for ten airports. The query takes advantage of the 'project' step that was
-introduced in TinkerPop 3.2.
+routes for ten airports. The query takes advantage of the 'project' step.
 
 [source,groovy]
 ----
@@ -6704,12 +6489,10 @@ Gremlin's scientific calculator - introducing 'math'
 
 As we have seen in some of the prior sections, there are some Gremlin steps such as
 'sum', 'count' and 'mean' that can be used to perform some fairly basic mathematical
-operations. In Apache TinkerPop version 3.3.1 a new 'math' step was introduced that
-allows us to perform scientific calculator style mathematical operations as part of a
-Gremlin graph traversal. As these operators build upon the Java Math class it is
-worth becoming familiar with that class if you are not already. Be aware that this
-functionality will only be available to you if the graph implementation that you are
-using supports Apache TInkerPop 3.3.1 or higher.
+operations. In addition to those steps, 'math' step was provides us to perform
+scientific calculator style mathematical operations as part of a Gremlin graph
+traversal. As these operators build upon the Java Math class it is worth becoming
+familiar with that class if you are not already.
 
 The table below provides a summary of the available operators sorted alphabetically.
 
@@ -6751,9 +6534,6 @@ itself. There are ways to easily work around this however as we shall see below.
 have not attempted to give an example of every single operator being used but the
 examples provided should provide all of the basic building blocks you will need to
 incorporate mathematical operators into your own Gremlin queries.
-
-TIP: These features require that the graph database system you are using supports a
-TinkerPop version of 3.3.1 or higher.
 
 [[arithmentic]]
 Performing simple arithmetic
@@ -7237,9 +7017,6 @@ Including an index with results - introducing 'withIndex' and 'indexed'
 If for any reason you wanted an index value included as part of the results from a
 query you can use the Groovy 'withIndex' or 'indexed' methods as shown below.
 
-NOTE: As covered in the next section, a native Gremlin 'index' step was introduced in
-the Apache TinkerPop 3.4 release.
-
 The 'withIndex' method adds the index value at the end of a list whereas the
 'indexed' method adds it at the start. You can provide a starting index value as a
 parameter. If no value is provided the default value for the first index will be
@@ -7286,20 +7063,16 @@ g.V().has('region','US-OK').values('code').indexed(1)
 ----
 
 [[tp34index]]
-The new 'index' step added in TinkerPop 3.4
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The 'index' step
+^^^^^^^^^^^^^^^^
 
-Apache TinkerPop version 3.4, released at the start of 2019, added a native 'index'
-step to the Gremlin language. A new 'with' modulator was also added that can be used
-to control how the index step behaves. Unlike the native 'Groovy' methods, there is
-no way to specify the starting value for the index range.
+The  'index' step adds a counter value to a 'list' or 'map' object and usage only
+really makes sense in that context. As shown below, without a 'fold' step in the
+query, the result set will consist of a number of individual lists all with an index
+of zero.
 
 TIP: The official Apache TinkerPop documentation for the 'index' step can be found at
 the following link http://tinkerpop.apache.org/docs/current/reference/#index-step.
-
-The use of 'index' only really makes sense in the context of a collection such as a
-'list' or a 'map'. As shown below, without a 'fold' step in the query, the result set
-will consist of a number of individual lists all with an index of zero.
 
 [source,groovy]
 ----
@@ -7522,7 +7295,7 @@ g.V().has('runways',gte(6)).values('code')
 Next, let's look at two ways of finding flights from airports in South America to
 Miami. The first query uses 'select' which is what we would have had to do in the
 TinkerPop 2 days. The second query, which feels cleaner to me, uses the 'path' and
-'by' step combination introduced in TinkerPop 3.
+'by' step combination introduced in TinkerPop.
 
 [source,groovy]
 ----


### PR DESCRIPTION
Removed references to TinkerPop versions that are now basically referring to features far enough in the past that they simply reflect the current way of doing things. We will probably keep this approach to mentioning versions but base it from a more current version of TinkerPop. Did not remove references to versions in the "Introduction" where it was introducing specific versions and their new features as that carries a history that makes sense in that context.